### PR TITLE
Rework compose stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+DB_NAME=citadel-m0n1t0r_database
+DB_USER=citadel-m0n1t0r_user
+DB_PW=citadel-m0n1t0r_change_me

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:latest
+FROM docker.io/library/python:latest
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -3,3 +3,8 @@
 > [!NOTE]
 > This is an anti-cheat developed for CTF-Citadel hosting platform. <br/>
 > There is no built-in authentication/security as it is only supposed to be accessed from within the docker-network.
+
+## Configuration
+
+The connection information for the database can be configured by using a`.env`-file.
+A example file is provided as `.env.example`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,17 +8,25 @@ services:
     ports:
       - "8888:8888"
       - "9999:9999"
+    depends_on:
+      db:
+        condition: service_healthy
     environment:
       DB_NAME: ${DB_NAME}
       DB_USER: ${DB_USER}
       DB_PW: ${DB_PW}
-      DB_HOST: ${DB_HOST}
+      DB_HOST: db
     restart: always
 
   db:
-    image: postgres:latest
+    image: docker.io/library/postgres:latest
     restart: always
     environment:
       POSTGRES_DB: ${DB_NAME}
       POSTGRES_USER: ${DB_USER}
       POSTGRES_PASSWORD: ${DB_PW}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -d ${POSTGRES_DB}"]
+      interval: 10s
+      retries: 5
+      timeout: 10s


### PR DESCRIPTION
With this PR I would like to rework/introduce the following things into the existing compose-stack.

### fully-qualified image names
Since some container-manager (such as podman) depend on fully-qualified image names I explicitly specified the docker-registry

### explicit startup order
I added a dependencie to `python-app` for the database and also specified a healthcheck for the database. This should prevent `python-app` to start and connect to the database before the container and database are present.

 ### example .env-file
 Since the original `.env`-file is ignored from git, I added a example one with all environment variables needed to start the compose stack. I also checked the code, I hope I didn't miss any.  

Since the containers are in the same network, it is possible to use the container name as hostname and let the docker dns resolve the name. Therefore I removed `DB_HOST`.